### PR TITLE
Fix password resets

### DIFF
--- a/lib/generators/authentication/templates/erb/identity/password_resets/edit.html.erb.tt
+++ b/lib/generators/authentication/templates/erb/identity/password_resets/edit.html.erb.tt
@@ -13,7 +13,7 @@
     </div>
   <%% end %>
 
-  <%%= form.hidden_field :token, value: params[:token] %>
+  <%%= form.hidden_field :sid, value: params[:sid] %>
 
   <div>
     <%%= form.label :password, "New password", style: "display: block" %>

--- a/lib/generators/authentication/templates/test_unit/system/identity/password_resets_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/system/identity/password_resets_test.rb.tt
@@ -17,7 +17,7 @@ class Identity::PasswordResetsTest < ApplicationSystemTestCase
   end
 
   test "updating password" do
-    visit edit_identity_password_reset_url(token: @sid)
+    visit edit_identity_password_reset_url(sid: @sid)
 
     fill_in "New password", with: "Secret6*4*2*"
     fill_in "Confirm new password", with: "Secret6*4*2*"

--- a/lib/generators/authentication/templates/test_unit/system/identity/password_resets_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/system/identity/password_resets_test.rb.tt
@@ -3,7 +3,7 @@ require "application_system_test_case"
 class Identity::PasswordResetsTest < ApplicationSystemTestCase
   setup do
     @user = users(:lazaro_nixon)
-    @sid = @user.signed_id(purpose: :password_reset, expires_in: 20.minutes)
+    @sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
   end
 
   test "sending a password reset email" do


### PR DESCRIPTION
After following the README set and running the default generator, the password resets system tests fail.

The [password resets controller looks up the token with `params[:sid]`](https://github.com/lazaronixon/authentication-zero/blob/c6c93b9849016d0cf871144b68ca03ada97bb4a0/lib/generators/authentication/templates/controllers/html/identity/password_resets_controller.rb.tt#L34), but the form sends `token`. Also, the [password reset mailer links to the edit view with an `sid` param](https://github.com/lazaronixon/authentication-zero/blob/c6c93b9849016d0cf871144b68ca03ada97bb4a0/lib/generators/authentication/templates/erb/user_mailer/password_reset.html.erb.tt#L5), but the form references `params[:token]`.

This PR fixes those references and generates a signed ID from `@user.password_reset_tokens.create…`