### PR TITLE
Fix identity emails system test.

### DIFF
--- a/lib/generators/authentication/templates/test_unit/system/identity/emails_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/system/identity/emails_test.rb.tt
@@ -8,7 +8,6 @@ class Identity::EmailsTest < ApplicationSystemTestCase
   test "updating the email" do
     click_on "Change email address"
 
-    fill_in "Current password", with: "Secret1*3*5*"
     fill_in "New email", with: "new_email@hey.com"
     click_on "Save changes"
 


### PR DESCRIPTION
Current password is not required in the default installation