### PR TITLE
add support for Rails 7.1 `authenticate_by`

### DIFF
--- a/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
@@ -12,9 +12,9 @@ class SessionsController < ApplicationController
   end
 
   def create
-    user = User.find_by(email: params[:email])
+    user = User.authenticate_by(login_params)
 
-    if user && user.authenticate(params[:password])
+    if user.present?
       <%- if two_factor? -%>
       if user.otp_secret
         signed_id = user.signed_id(purpose: :authentication_challenge, expires_in: 20.minutes)
@@ -44,5 +44,9 @@ class SessionsController < ApplicationController
   private
     def set_session
       @session = Current.user.sessions.find(params[:id])
+    end
+
+    def login_params
+      params.permit(:email, :password).with_defaults(email: "", password: "")
     end
 end


### PR DESCRIPTION
This PR swaps out the existing [`authenticate`](https://api.rubyonrails.org/classes/ActiveModel/SecurePassword/ClassMethods.html#method-i-has_secure_password) method for the the new Rails 7.1 method [`authenticate_by`](https://edgeapi.rubyonrails.org/classes/ActiveRecord/SecurePassword/ClassMethods.html#method-i-authenticate_by).

Here's a quick description:

> Given a set of attributes, finds a record using the non-password attributes, and then authenticates that record using the password attributes. Returns the record if authentication succeeds; otherwise, returns nil.
> 
> Regardless of whether a record is found, authenticate_by will cryptographically digest the given password attributes. This behavior helps mitigate timing-based enumeration attacks, wherein an attacker can determine if a passworded record exists even without knowing the password.
> 
> Raises an ArgumentError if the set of attributes doesn't contain at least one password and one non-password attribute.

Closes #4