### PR TITLE
implements `generates_token_for` support for password resets and email confirmations

### DIFF
--- a/lib/generators/authentication/authentication_generator.rb
+++ b/lib/generators/authentication/authentication_generator.rb
@@ -43,7 +43,6 @@ class AuthenticationGenerator < Rails::Generators::Base
     migration_template "migrations/create_users_migration.rb", "#{db_migrate_path}/create_users.rb"
     migration_template "migrations/create_sessions_migration.rb", "#{db_migrate_path}/create_sessions.rb"
     migration_template "migrations/create_email_verification_tokens_migration.rb", "#{db_migrate_path}/create_email_verification_tokens.rb"
-    migration_template "migrations/create_password_reset_tokens_migration.rb", "#{db_migrate_path}/create_password_reset_tokens.rb"
     migration_template "migrations/create_events_migration.rb", "#{db_migrate_path}/create_events.rb" if options.trackable?
   end
 
@@ -51,7 +50,6 @@ class AuthenticationGenerator < Rails::Generators::Base
     template "models/user.rb", "app/models/user.rb"
     template "models/session.rb", "app/models/session.rb"
     template "models/email_verification_token.rb", "app/models/email_verification_token.rb"
-    template "models/password_reset_token.rb", "app/models/password_reset_token.rb"
     template "models/current.rb", "app/models/current.rb"
     template "models/event.rb", "app/models/event.rb" if options.trackable?
   end

--- a/lib/generators/authentication/authentication_generator.rb
+++ b/lib/generators/authentication/authentication_generator.rb
@@ -3,20 +3,20 @@ require "rails/generators/active_record"
 class AuthenticationGenerator < Rails::Generators::Base
   include ActiveRecord::Generators::Migration
 
-  class_option :api,             type: :boolean, desc: "Generates API authentication"
-  class_option :pwned,           type: :boolean, desc: "Add pwned password validation"
+  class_option :api, type: :boolean, desc: "Generates API authentication"
+  class_option :pwned, type: :boolean, desc: "Add pwned password validation"
   class_option :code_verifiable, type: :boolean, desc: "Add email verification using a code for api"
-  class_option :sudoable,        type: :boolean, desc: "Add password request before sensitive data changes"
-  class_option :lockable,        type: :boolean, desc: "Add password reset locking"
-  class_option :omniauthable,    type: :boolean, desc: "Add social login support"
-  class_option :trackable,       type: :boolean, desc: "Add activity log support"
-  class_option :two_factor,      type: :boolean, desc: "Add two factor authentication"
+  class_option :sudoable, type: :boolean, desc: "Add password request before sensitive data changes"
+  class_option :lockable, type: :boolean, desc: "Add password reset locking"
+  class_option :omniauthable, type: :boolean, desc: "Add social login support"
+  class_option :trackable, type: :boolean, desc: "Add activity log support"
+  class_option :two_factor, type: :boolean, desc: "Add two factor authentication"
 
   source_root File.expand_path("templates", __dir__)
 
   def add_gems
     uncomment_lines "Gemfile", /"bcrypt"/
-    uncomment_lines "Gemfile", /"redis"/  if redis?
+    uncomment_lines "Gemfile", /"redis"/ if redis?
     uncomment_lines "Gemfile", /"kredis"/ if redis?
 
     if options.pwned?
@@ -42,14 +42,12 @@ class AuthenticationGenerator < Rails::Generators::Base
   def create_migrations
     migration_template "migrations/create_users_migration.rb", "#{db_migrate_path}/create_users.rb"
     migration_template "migrations/create_sessions_migration.rb", "#{db_migrate_path}/create_sessions.rb"
-    migration_template "migrations/create_email_verification_tokens_migration.rb", "#{db_migrate_path}/create_email_verification_tokens.rb"
     migration_template "migrations/create_events_migration.rb", "#{db_migrate_path}/create_events.rb" if options.trackable?
   end
 
   def create_models
     template "models/user.rb", "app/models/user.rb"
     template "models/session.rb", "app/models/session.rb"
-    template "models/email_verification_token.rb", "app/models/email_verification_token.rb"
     template "models/current.rb", "app/models/current.rb"
     template "models/event.rb", "app/models/event.rb" if options.trackable?
   end
@@ -59,32 +57,30 @@ class AuthenticationGenerator < Rails::Generators::Base
   end
 
   def create_controllers
-    template  "controllers/#{format_folder}/application_controller.rb", "app/controllers/application_controller.rb", force: true
+    template "controllers/#{format_folder}/application_controller.rb", "app/controllers/application_controller.rb", force: true
 
     directory "controllers/#{format_folder}/identity", "app/controllers/identity"
     directory "controllers/#{format_folder}/two_factor_authentication", "app/controllers/two_factor_authentication" if two_factor?
-    template  "controllers/#{format_folder}/sessions_controller.rb", "app/controllers/sessions_controller.rb"
-    template  "controllers/#{format_folder}/passwords_controller.rb", "app/controllers/passwords_controller.rb"
-    template  "controllers/#{format_folder}/registrations_controller.rb", "app/controllers/registrations_controller.rb"
-    template  "controllers/#{format_folder}/sessions/sudos_controller.rb", "app/controllers/sessions/sudos_controller.rb" if options.sudoable?
-    template  "controllers/#{format_folder}/sessions/omniauth_controller.rb", "app/controllers/sessions/omniauth_controller.rb" if omniauthable?
-    template  "controllers/#{format_folder}/authentications/events_controller.rb", "app/controllers/authentications/events_controller.rb" if options.trackable?
+    template "controllers/#{format_folder}/sessions_controller.rb", "app/controllers/sessions_controller.rb"
+    template "controllers/#{format_folder}/passwords_controller.rb", "app/controllers/passwords_controller.rb"
+    template "controllers/#{format_folder}/registrations_controller.rb", "app/controllers/registrations_controller.rb"
+    template "controllers/#{format_folder}/sessions/sudos_controller.rb", "app/controllers/sessions/sudos_controller.rb" if options.sudoable?
+    template "controllers/#{format_folder}/sessions/omniauth_controller.rb", "app/controllers/sessions/omniauth_controller.rb" if omniauthable?
+    template "controllers/#{format_folder}/authentications/events_controller.rb", "app/controllers/authentications/events_controller.rb" if options.trackable?
   end
 
   def create_views
+    directory "erb/user_mailer", "app/views/user_mailer"
+    directory "erb/session_mailer", "app/views/session_mailer"
     if options.api?
-      directory "erb/user_mailer", "app/views/user_mailer"
-      directory "erb/session_mailer", "app/views/session_mailer"
     else
-      directory "erb/user_mailer", "app/views/user_mailer"
-      directory "erb/session_mailer", "app/views/session_mailer"
 
       directory "erb/identity", "app/views/identity"
       directory "erb/passwords", "app/views/passwords"
       directory "erb/registrations", "app/views/registrations"
 
-      template  "erb/sessions/index.html.erb", "app/views/sessions/index.html.erb"
-      template  "erb/sessions/new.html.erb", "app/views/sessions/new.html.erb"
+      template "erb/sessions/index.html.erb", "app/views/sessions/index.html.erb"
+      template "erb/sessions/new.html.erb", "app/views/sessions/new.html.erb"
 
       directory "erb/sessions/sudos", "app/views/sessions/sudos" if options.sudoable?
 
@@ -133,23 +129,24 @@ class AuthenticationGenerator < Rails::Generators::Base
   end
 
   private
-    def format_folder
-      options.api? ? "api" : "html"
-    end
 
-    def omniauthable?
-      options.omniauthable? && !options.api?
-    end
+  def format_folder
+    options.api? ? "api" : "html"
+  end
 
-    def two_factor?
-      options.two_factor? && !options.api?
-    end
+  def omniauthable?
+    options.omniauthable? && !options.api?
+  end
 
-    def code_verifiable?
-      options.code_verifiable? && options.api?
-    end
+  def two_factor?
+    options.two_factor? && !options.api?
+  end
 
-    def redis?
-      options.lockable? || options.sudoable? || code_verifiable?
-    end
+  def code_verifiable?
+    options.code_verifiable? && options.api?
+  end
+
+  def redis?
+    options.lockable? || options.sudoable? || code_verifiable?
+  end
 end

--- a/lib/generators/authentication/templates/controllers/api/identity/email_verifications_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/api/identity/email_verifications_controller.rb.tt
@@ -22,7 +22,7 @@ class Identity::EmailVerificationsController < ApplicationController
         render json: { error: "That email verification code is invalid" }, status: :bad_request
       end
     <%- else -%>
-      @token = EmailVerificationToken.find_signed!(params[:sid]); @user = @token.user
+      @user = User.find_by_token_for!(:email_verification, params[:sid])
     rescue
       render json: { error: "That email verification link is invalid" }, status: :bad_request
     <%- end -%>

--- a/lib/generators/authentication/templates/controllers/api/identity/password_resets_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/api/identity/password_resets_controller.rb.tt
@@ -16,7 +16,7 @@ class Identity::PasswordResetsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      @token.destroy; render json: @user
+      render json: @user
     else
       render json: @user.errors, status: :unprocessable_entity
     end
@@ -24,7 +24,7 @@ class Identity::PasswordResetsController < ApplicationController
 
   private
     def set_user
-      @token = PasswordResetToken.find_signed!(params[:sid]); @user = @token.user
+      @user = User.find_by_token_for!(:password_reset, params[:sid])
     rescue
       render json: { error: "That password reset link is invalid" }, status: :bad_request
     end

--- a/lib/generators/authentication/templates/controllers/html/identity/email_verifications_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/identity/email_verifications_controller.rb.tt
@@ -15,7 +15,7 @@ class Identity::EmailVerificationsController < ApplicationController
 
   private
     def set_user
-      @token = EmailVerificationToken.find_signed!(params[:sid]); @user = @token.user
+      @user = User.find_by_token_for!(:email_verification, params[:sid])
     rescue
       redirect_to edit_identity_email_path, alert: "That email verification link is invalid"
     end

--- a/lib/generators/authentication/templates/controllers/html/identity/password_resets_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/identity/password_resets_controller.rb.tt
@@ -23,7 +23,7 @@ class Identity::PasswordResetsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      @token.destroy; redirect_to(sign_in_path, notice: "Your password was reset successfully. Please sign in")
+      redirect_to(sign_in_path, notice: "Your password was reset successfully. Please sign in")
     else
       render :edit, status: :unprocessable_entity
     end
@@ -31,7 +31,7 @@ class Identity::PasswordResetsController < ApplicationController
 
   private
     def set_user
-      @token = PasswordResetToken.find_signed!(params[:sid]); @user = @token.user
+      @user = User.find_by_token_for!(:password_reset, params[:sid])
     rescue
       redirect_to new_identity_password_reset_path, alert: "That password reset link is invalid"
     end

--- a/lib/generators/authentication/templates/mailers/user_mailer.rb.tt
+++ b/lib/generators/authentication/templates/mailers/user_mailer.rb.tt
@@ -11,7 +11,7 @@ class UserMailer < ApplicationMailer
     <%- if code_verifiable? -%>
     @user.verification_code.value = rand.to_s[2..7]
     <%- else -%>
-    @signed_id = @user.email_verification_tokens.create.signed_id(expires_in: 2.days)
+    @signed_id = @user.generate_token_for(:email_verification)
     <%- end -%>
 
     mail to: @user.email, subject: "Verify your email"

--- a/lib/generators/authentication/templates/mailers/user_mailer.rb.tt
+++ b/lib/generators/authentication/templates/mailers/user_mailer.rb.tt
@@ -1,7 +1,7 @@
 class UserMailer < ApplicationMailer
   def password_reset
     @user = params[:user]
-    @signed_id = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+    @signed_id = @user.generate_token_for(:password_reset)
 
     mail to: @user.email, subject: "Reset your password"
   end

--- a/lib/generators/authentication/templates/migrations/create_email_verification_tokens_migration.rb.tt
+++ b/lib/generators/authentication/templates/migrations/create_email_verification_tokens_migration.rb.tt
@@ -1,7 +1,0 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
-  def change
-    create_table :email_verification_tokens do |t|
-      t.references :user, null: false, foreign_key: true
-    end
-  end
-end

--- a/lib/generators/authentication/templates/migrations/create_password_reset_tokens_migration.rb.tt
+++ b/lib/generators/authentication/templates/migrations/create_password_reset_tokens_migration.rb.tt
@@ -1,7 +1,0 @@
-class <%= migration_class_name %> < ActiveRecord::Migration[<%= ActiveRecord::Migration.current_version %>]
-  def change
-    create_table :password_reset_tokens do |t|
-      t.references :user, null: false, foreign_key: true
-    end
-  end
-end

--- a/lib/generators/authentication/templates/models/email_verification_token.rb.tt
+++ b/lib/generators/authentication/templates/models/email_verification_token.rb.tt
@@ -1,3 +1,0 @@
-class EmailVerificationToken < ApplicationRecord
-  belongs_to :user
-end

--- a/lib/generators/authentication/templates/models/password_reset_token.rb.tt
+++ b/lib/generators/authentication/templates/models/password_reset_token.rb.tt
@@ -1,3 +1,0 @@
-class PasswordResetToken < ApplicationRecord
-  belongs_to :user
-end

--- a/lib/generators/authentication/templates/models/user.rb.tt
+++ b/lib/generators/authentication/templates/models/user.rb.tt
@@ -1,8 +1,14 @@
 class User < ApplicationRecord
   has_secure_password
 
+  PASSWORD_RESET_TOKEN_VALIDITY = 20.minutes
+  EMAIL_VERIFICATION_TOKEN_VALIDITY = 2.days
+
+  generates_token_for :password_reset, expires_in: PASSWORD_RESET_TOKEN_VALIDITY do
+    BCrypt::Password.new(password_digest).salt[-10..]
+  end
+
   has_many :email_verification_tokens, dependent: :destroy
-  has_many :password_reset_tokens, dependent: :destroy
 
   has_many :sessions, dependent: :destroy
   <%- if options.trackable? -%>

--- a/lib/generators/authentication/templates/models/user.rb.tt
+++ b/lib/generators/authentication/templates/models/user.rb.tt
@@ -1,4 +1,6 @@
 class User < ApplicationRecord
+  EMAIL_VERIFICATION_TOKEN_VALIDITY = 2.days
+
   has_secure_password
 
   PASSWORD_RESET_TOKEN_VALIDITY = 20.minutes
@@ -8,7 +10,9 @@ class User < ApplicationRecord
     BCrypt::Password.new(password_digest).salt[-10..]
   end
 
-  has_many :email_verification_tokens, dependent: :destroy
+  generates_token_for :email_verification, expires_in: EMAIL_VERIFICATION_TOKEN_VALIDITY do
+    email
+  end
 
   has_many :sessions, dependent: :destroy
   <%- if options.trackable? -%>

--- a/lib/generators/authentication/templates/test_unit/controllers/api/identity/password_resets_controller_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/controllers/api/identity/password_resets_controller_test.rb.tt
@@ -6,8 +6,8 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should send a password reset email" do
-    assert_enqueued_email_with UserMailer, :password_reset, args: { user: @user } do
-      post identity_password_reset_url, params: { email: @user.email }
+    assert_enqueued_email_with UserMailer, :password_reset, args: {user: @user} do
+      post identity_password_reset_url, params: {email: @user.email}
     end
 
     assert_response :no_content
@@ -15,7 +15,7 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
   test "should not send a password reset email to a nonexistent email" do
     assert_no_enqueued_emails do
-      post identity_password_reset_url, params: { email: "invalid_email@hey.com" }
+      post identity_password_reset_url, params: {email: "invalid_email@hey.com"}
     end
 
     assert_response :bad_request
@@ -26,7 +26,7 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     @user.update! verified: false
 
     assert_no_enqueued_emails do
-      post identity_password_reset_url, params: { email: @user.email }
+      post identity_password_reset_url, params: {email: @user.email}
     end
 
     assert_response :bad_request
@@ -34,16 +34,31 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update password" do
-    sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+    sid = @user.generate_token_for(:password_reset)
 
-    patch identity_password_reset_url, params: { sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    patch identity_password_reset_url, params: {sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*"}
     assert_response :success
   end
 
   test "should not update password with expired token" do
-    sid_exp = @user.password_reset_tokens.create.signed_id(expires_in: 0.minutes)
+    sid = @user.generate_token_for(:password_reset)
 
-    patch identity_password_reset_url, params: { sid: sid_exp, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    travel User::PASSWORD_RESET_TOKEN_VALIDITY + 1.minute
+
+    patch identity_password_reset_url, params: {sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*"}
+    assert_response :bad_request
+    assert_equal "That password reset link is invalid", response.parsed_body["error"]
+  end
+
+  test "should not update a password that was already updated" do
+    sid = @user.generate_token_for(:password_reset)
+
+    @user.update!(password: "Secret6*4*2*")
+
+    patch identity_password_reset_url, params: {
+      sid: sid, password: "Secret7*8*9*", password_confirmation: "Secret7*8*9*"
+    }
+
     assert_response :bad_request
     assert_equal "That password reset link is invalid", response.parsed_body["error"]
   end

--- a/lib/generators/authentication/templates/test_unit/controllers/html/identity/password_resets_controller_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/controllers/html/identity/password_resets_controller_test.rb.tt
@@ -11,15 +11,15 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should get edit" do
-    sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+    sid = @user.generate_token_for(:password_reset)
 
     get edit_identity_password_reset_url(sid: sid)
     assert_response :success
   end
 
   test "should send a password reset email" do
-    assert_enqueued_email_with UserMailer, :password_reset, args: { user: @user } do
-      post identity_password_reset_url, params: { email: @user.email }
+    assert_enqueued_email_with UserMailer, :password_reset, args: {user: @user} do
+      post identity_password_reset_url, params: {email: @user.email}
     end
 
     assert_redirected_to sign_in_url
@@ -27,7 +27,7 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
 
   test "should not send a password reset email to a nonexistent email" do
     assert_no_enqueued_emails do
-      post identity_password_reset_url, params: { email: "invalid_email@hey.com" }
+      post identity_password_reset_url, params: {email: "invalid_email@hey.com"}
     end
 
     assert_redirected_to new_identity_password_reset_url
@@ -38,7 +38,7 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
     @user.update! verified: false
 
     assert_no_enqueued_emails do
-      post identity_password_reset_url, params: { email: @user.email }
+      post identity_password_reset_url, params: {email: @user.email}
     end
 
     assert_redirected_to new_identity_password_reset_url
@@ -46,16 +46,31 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update password" do
-    sid = @user.password_reset_tokens.create.signed_id(expires_in: 20.minutes)
+    sid = @user.generate_token_for(:password_reset)
 
-    patch identity_password_reset_url, params: { sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    patch identity_password_reset_url, params: {sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*"}
     assert_redirected_to sign_in_url
   end
 
   test "should not update password with expired token" do
-    sid_exp = @user.password_reset_tokens.create.signed_id(expires_in: 0.minutes)
+    sid = @user.generate_token_for(:password_reset)
 
-    patch identity_password_reset_url, params: { sid: @sid_exp, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    travel User::PASSWORD_RESET_TOKEN_VALIDITY + 1.minute
+
+    patch identity_password_reset_url, params: {sid: sid, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*"}
+    assert_redirected_to new_identity_password_reset_url
+    assert_equal "That password reset link is invalid", flash[:alert]
+  end
+
+  test "should not update a password that was already updated" do
+    sid = @user.generate_token_for(:password_reset)
+
+    @user.update!(password: "Secret6*4*2*")
+
+    patch identity_password_reset_url, params: {
+      sid: sid, password: "Secret7*8*9*", password_confirmation: "Secret7*8*9*"
+    }
+
     assert_redirected_to new_identity_password_reset_url
     assert_equal "That password reset link is invalid", flash[:alert]
   end


### PR DESCRIPTION
Utilizes the new Rails 7.1 API [`generates_token_for`](https://github.com/rails/rails/pull/44189) in lieu of the current use of separate models/tables for password resets and email confirmations.

Closes #26.