### PR TITLE
Add post installation message

### DIFF
--- a/authentication-zero.gemspec
+++ b/authentication-zero.gemspec
@@ -19,4 +19,17 @@ Gem::Specification.new do |spec|
   spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
+
+  spec.post_install_message = <<~EOS
+    \n\e[1m\e[31m== Authentication Zero ==\e[0m\e[22m
+
+    It is recommended you keep Authentication Zero as part of your Gemfile even after you have ran the template
+    generators so that you can be kept up-to-date regarding important upstream changes and security updates.
+
+    For a full list of changes, go to: \e[4mhttps://github.com/lazaronixon/authentication-zero/blob/master/CHANGELOG.md\e[24m
+
+    Here are the three most recent release notes:
+
+    #{File.read('CHANGELOG.md').scan(/^##.*?(?=^##|\z)/m).first(3).join}
+  EOS
 end


### PR DESCRIPTION
This PR adds the proposed post installation message (Resolves lazaronixon/authentication-zero#52) so that users can be kept up-to-date regarding important changes to Authentication Zero.

Screenshot of the message:

<img width="987" alt="Screenshot 2023-01-12 at 1 21 38 AM" src="https://user-images.githubusercontent.com/16937/211992715-0001db01-e0c3-4727-afaa-17d6a3717a7b.png">

As of the current moment, the CHANGELOG is out of date for the most recent three minor version releases. A separate PR has been opened to update this: https://github.com/lazaronixon/authentication-zero/pull/54.

Please check these PRs out and provide feedback as needed. Thank you!
