### PR TITLE
Fix local variable reference typo in password reset test

### DIFF
--- a/lib/generators/authentication/templates/test_unit/controllers/html/identity/password_resets_controller_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/controllers/html/identity/password_resets_controller_test.rb.tt
@@ -55,7 +55,7 @@ class Identity::PasswordResetsControllerTest < ActionDispatch::IntegrationTest
   test "should not update password with expired token" do
     sid_exp = @user.password_reset_tokens.create.signed_id(expires_in: 0.minutes)
 
-    patch identity_password_reset_url, params: { sid: @sid_exp, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
+    patch identity_password_reset_url, params: { sid: sid_exp, password: "Secret6*4*2*", password_confirmation: "Secret6*4*2*" }
     assert_redirected_to new_identity_password_reset_url
     assert_equal "That password reset link is invalid", flash[:alert]
   end


### PR DESCRIPTION
In the template password_resets_controller_test.rb, Rubocop linting found an unused instance variable whilst I was working on a project. 

It looks like a typo as the next line references a local variable.

This PR is a simple fix for that. 

Thanks!