### PR TITLE
Update redirect route in 2FA totps controller

### DIFF
--- a/lib/generators/authentication/templates/controllers/html/two_factor_authentication/totps_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/two_factor_authentication/totps_controller.rb.tt
@@ -8,12 +8,12 @@ class TwoFactorAuthentication::TotpsController < ApplicationController
 
   def create
     if !@user.authenticate(params[:current_password])
-      redirect_to two_factor_authentication_totp_path, alert: "The password you entered is incorrect"
+      redirect_to new_two_factor_authentication_totp_path, alert: "The password you entered is incorrect"
     elsif @totp.verify(params[:code], drift_behind: 15)
       @user.update! otp_secret: params[:secret]
       redirect_to root_path, notice: "2FA is enabled on your account"
     else
-      redirect_to two_factor_authentication_totp_path, alert: "That code didn't work. Please try again"
+      redirect_to new_two_factor_authentication_totp_path, alert: "That code didn't work. Please try again"
     end
   end
 


### PR DESCRIPTION
The route being directed to here does exist as a method name, but only with the POST verb. When the redirect happens the subsequent GET request errors out.

This change updates the error redirect URL back to the new action, which is probably where the request was coming from.