### PR TITLE
Update Changelog 2.16.31 to 2.16.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## Authentication Zero 2.16.35 ##
+
+* Adjust relationship so that account has many users
+
+## Authentication Zero 2.16.34 ##
+
+* Adjust relationship so that account has one user
+
+## Authentication Zero 2.16.33 ##
+
+* Add account to user by default when tenantable
+
+## Authentication Zero 2.16.32 ##
+
+* Refactor account middleware for account scoping
+
+## Authentication Zero 2.16.31 ##
+
+* Remove raising exception when Current.account is nil in AccountScoped
+
 ## Authentication Zero 2.16.30 ##
 
 * Add multi-tenant artifacts that you can use. (--tenantable)


### PR DESCRIPTION
@lazaronixon Just updated the changelog based on your commits. Hopefully I didn't misread any of them.

Here are the diff compare links for all the version jumps:

2.16.31 -- https://github.com/lazaronixon/authentication-zero/compare/v2.16.30...v2.16.31

2.16.32 -- https://github.com/lazaronixon/authentication-zero/compare/v2.16.31...v2.16.32

2.16.33 -- https://github.com/lazaronixon/authentication-zero/compare/v2.16.31...v2.16.33

2.16.34 -- https://github.com/lazaronixon/authentication-zero/compare/v2.16.33...v2.16.34

2.16.35 -- https://github.com/lazaronixon/authentication-zero/compare/v2.16.34...v2.16.35

Feel free to amend/edit/replace any of the changelog entries for accuracy/corrections. Thanks!