### PR TITLE
Delegate user to session instead of a new a user attribute

### DIFF
--- a/lib/generators/authentication/templates/models/current.rb.tt
+++ b/lib/generators/authentication/templates/models/current.rb.tt
@@ -1,16 +1,14 @@
 class Current < ActiveSupport::CurrentAttributes
-  attribute :session, :user
+  attribute :session
   attribute :user_agent, :ip_address
   <%- if options.tenantable? %>
   attribute :account
   <%- end -%>
 
-  def session=(session)
-    super; self.user = session.user
-  end
+  delegate :user, to: :session, allow_nil: true
   <%- if options.tenantable? %>
-  def user=(user)
-    super; self.account = user.account
+  def session=(session)
+    super; self.account = session.user.account
   end
   <%- end -%>
 end


### PR DESCRIPTION
Delegate `user` to `session`, so we can't set a user without a session. When testing models it would be:

Before

```ruby
Current.user = users(:nixon) #Current.session is nil
```

After:

```ruby
Current.session = users(:nixon).sessions.create
```