### PR TITLE
Fix bug where generates_token_for isn't expiring/invalid after value is updated

### DIFF
--- a/lib/generators/authentication/templates/models/user.rb.tt
+++ b/lib/generators/authentication/templates/models/user.rb.tt
@@ -1,8 +1,13 @@
 class User < ApplicationRecord
   has_secure_password
 
-  generates_token_for :email_verification, expires_in: 2.days { email }
-  generates_token_for :password_reset, expires_in: 20.minutes { password_salt.last(10) }
+  generates_token_for :email_verification, expires_in: 2.days do
+    email
+  end
+  generates_token_for :password_reset, expires_in: 20.minutes do
+    password_salt.last(10)
+  end
+
   <%- if options.tenantable? %>
   belongs_to :account
   <%- end -%>


### PR DESCRIPTION
When using generates_token_for, the block needs to use an explicit `do`/`end`, not curly braces. With curly braces, the token does not expire/become invalid when the block value is updated.

My best guess is that when curly braces are used, Rails is interpreting the curly braces as a hash arg, rather than as a block arg.

https://github.com/lazaronixon/authentication-zero/assets/4053800/19f6b7a6-6a06-428e-a723-a2e90db9b127

Thanks!