### PR TITLE
Update process for user to change email

### DIFF
--- a/lib/generators/authentication/templates/erb/identity/emails/edit.html.erb.tt
+++ b/lib/generators/authentication/templates/erb/identity/emails/edit.html.erb.tt
@@ -2,38 +2,38 @@
 
 <%% if Current.user.verified? %>
   <h1>Change your email</h1>
-<%% else %>
-  <h1>Verify your email</h1>
-  <p>We sent a verification email to the address below. Check that email and follow those instructions to confirm it's your email address.</p>
-  <p><%%= button_to "Re-send verification email", identity_email_verification_path %></p>
-<%% end %>
+  <%%= form_with(url: identity_email_path, method: :patch) do |form| %>
+    <%% if @user.errors.any? %>
+      <div style="color: red">
+        <h2><%%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
+        <ul>
+          <%% @user.errors.each do |error| %>
+            <li><%%= error.full_message %></li>
+          <%% end %>
+        </ul>
+      </div>
+    <%% end %>
 
-<%%= form_with(url: identity_email_path, method: :patch) do |form| %>
-  <%% if @user.errors.any? %>
-    <div style="color: red">
-      <h2><%%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
+    <div>
+      <%%= form.label :email, "New email", style: "display: block" %>
+      <%%= form.email_field :email, required: true, autofocus: true %>
+    </div>
 
-      <ul>
-        <%% @user.errors.each do |error| %>
-          <li><%%= error.full_message %></li>
-        <%% end %>
-      </ul>
+    <div>
+      <%%= form.label :password_challenge, style: "display: block" %>
+      <%%= form.password_field :password_challenge, required: true, autocomplete: "current-password" %>
+    </div>
+
+    <div>
+      <%%= form.submit "Save changes" %>
     </div>
   <%% end %>
-
-  <div>
-    <%%= form.label :email, "New email", style: "display: block" %>
-    <%%= form.email_field :email, required: true, autofocus: true %>
-  </div>
-
-  <div>
-    <%%= form.label :password_challenge, style: "display: block" %>
-    <%%= form.password_field :password_challenge, required: true, autocomplete: "current-password" %>
-  </div>
-
-  <div>
-    <%%= form.submit "Save changes" %>
-  </div>
+<%% else %>
+  <h1>Verify your email</h1>
+  <p>You must verify your current email address before it can be changed in your profile.</p>
+  <p>We sent a verification email to the address below. Check that email and follow those instructions to confirm it's your email address.</p>
+  <p><%%= @user.email %></p>
+  <p><%%= button_to "Re-send verification email", identity_email_verification_path %></p>
 <%% end %>
 
 <br>

--- a/lib/generators/authentication/templates/models/user.rb.tt
+++ b/lib/generators/authentication/templates/models/user.rb.tt
@@ -35,7 +35,7 @@ class User < ApplicationRecord
 
   normalizes :email, with: -> { _1.strip.downcase }
 
-  before_validation if: :email_changed?, on: :update do
+  before_update if: :email_changed? do
     self.verified = false
   end
   <%- if two_factor? %>

--- a/lib/generators/authentication/templates/test_unit/system/identity/emails_test.rb.tt
+++ b/lib/generators/authentication/templates/test_unit/system/identity/emails_test.rb.tt
@@ -15,6 +15,16 @@ class Identity::EmailsTest < ApplicationSystemTestCase
     assert_text "Your email has been changed"
   end
 
+  test "updating the email with wrong password" do
+    click_on "Change email address"
+
+    fill_in "New email", with: "new_email@hey.com"
+    fill_in "Password challenge", with: "Wrong1*3*5*"
+    click_on "Save changes"
+
+    assert_text "Password challenge is invalid"
+  end
+
   test "sending a verification email" do
     @user.update! verified: false
 


### PR DESCRIPTION
When visiting the identity/emails/edit page the form would be shown even if the user was not verified. After fixing that, other problems appeared, related to the callback in the User model prematurely setting the verified status to false when submitting the form with an incorrect password. The solution was to use a before_update callback instead of before_validation.

There was also no system test for a user attempting to change their email address but using the wrong password. Since that is related to this problem I have added that as well.