### PR TITLE
bugfix: omit password digest in register response for api

### DIFF
--- a/lib/generators/authentication/templates/controllers/api/registrations_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/api/registrations_controller.rb.tt
@@ -6,7 +6,7 @@ class RegistrationsController < ApplicationController
 
     if @user.save
       send_email_verification
-      render json: @user, status: :created
+        render json: @user.as_json(except: [:password_digest]), status: :created
     else
       render json: @user.errors, status: :unprocessable_entity
     end

--- a/lib/generators/authentication/templates/controllers/api/registrations_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/api/registrations_controller.rb.tt
@@ -6,7 +6,7 @@ class RegistrationsController < ApplicationController
 
     if @user.save
       send_email_verification
-        render json: @user.as_json(except: [:password_digest]), status: :created
+      render json: @user.as_json(except: [:password_digest]), status: :created
     else
       render json: @user.errors, status: :unprocessable_entity
     end


### PR DESCRIPTION
Wondering if the digest should be omitted from the response when creating a user. I'm unsure if this exists elsewhere in application right now.