### PR TITLE
Use :see_other on redirects after DESTROY

### DIFF
--- a/lib/generators/authentication/templates/controllers/html/identity/emails_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/identity/emails_controller.rb.tt
@@ -6,7 +6,7 @@ class Identity::EmailsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to_root
+      redirect_to_root, status: :see_other
     else
       render :edit, status: :unprocessable_entity
     end

--- a/lib/generators/authentication/templates/controllers/html/identity/password_resets_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/identity/password_resets_controller.rb.tt
@@ -23,7 +23,7 @@ class Identity::PasswordResetsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to sign_in_path, notice: "Your password was reset successfully. Please sign in"
+      redirect_to sign_in_path, status: :see_other, notice: "Your password was reset successfully. Please sign in"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/lib/generators/authentication/templates/controllers/html/passwords_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/passwords_controller.rb.tt
@@ -6,7 +6,7 @@ class PasswordsController < ApplicationController
 
   def update
     if @user.update(user_params)
-      redirect_to root_path, notice: "Your password has been changed"
+      redirect_to root_path, status: :see_other, notice: "Your password has been changed"
     else
       render :edit, status: :unprocessable_entity
     end

--- a/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
@@ -34,7 +34,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    @session.destroy; redirect_to(sessions_path, notice: "That session has been logged out"), status: :see_other
+    @session.destroy; redirect_to(sessions_path, status: :see_other, notice: "That session has been logged out")
   end
 
   private

--- a/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/sessions_controller.rb.tt
@@ -34,7 +34,7 @@ class SessionsController < ApplicationController
   end
 
   def destroy
-    @session.destroy; redirect_to(sessions_path, notice: "That session has been logged out")
+    @session.destroy; redirect_to(sessions_path, notice: "That session has been logged out"), status: :see_other
   end
 
   private

--- a/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
@@ -28,7 +28,7 @@ class TwoFactorAuthentication::Profile::SecurityKeysController < ApplicationCont
 
   def destroy
     @security_key.destroy
-    redirect_to two_factor_authentication_profile_security_keys_path, notice: "#{@security_key.name} has been removed", status: :see_other
+    redirect_to two_factor_authentication_profile_security_keys_path, status: :see_other, notice: "#{@security_key.name} has been removed"
   end
 
   private

--- a/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
@@ -28,7 +28,7 @@ class TwoFactorAuthentication::Profile::SecurityKeysController < ApplicationCont
 
   def destroy
     @security_key.destroy
-    redirect_to two_factor_authentication_profile_security_keys_path, notice: "#{@security_key.name} has been removed"
+    redirect_to two_factor_authentication_profile_security_keys_path, notice: "#{@security_key.name} has been removed", status: :see_other
   end
 
   private

--- a/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/security_keys_controller.rb.tt
@@ -23,7 +23,7 @@ class TwoFactorAuthentication::Profile::SecurityKeysController < ApplicationCont
 
   def update
     @security_key.update! name: params[:name]
-    redirect_to two_factor_authentication_profile_security_keys_path, notice: "Your changes have been saved"
+    redirect_to two_factor_authentication_profile_security_keys_path, status: :see_other, notice: "Your changes have been saved"
   end
 
   def destroy

--- a/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/totps_controller.rb.tt
+++ b/lib/generators/authentication/templates/controllers/html/two_factor_authentication/profile/totps_controller.rb.tt
@@ -17,7 +17,7 @@ class TwoFactorAuthentication::Profile::TotpsController < ApplicationController
 
   def update
     @user.update! otp_secret: ROTP::Base32.random
-    redirect_to new_two_factor_authentication_profile_totp_path
+    redirect_to new_two_factor_authentication_profile_totp_path, status: :see_other
   end
 
   private


### PR DESCRIPTION
It is good practice to use 303 on redirect to make sure the new request is a GET and not another DELETE or POST.

EDIT: Also added to UPDATE/PUT methods.

For reference [API docs](https://api.rubyonrails.org/classes/ActionController/Redirecting.html)